### PR TITLE
add types of user after authintication

### DIFF
--- a/modules/CompanyUser/Filters/CompanyUserFilter.php
+++ b/modules/CompanyUser/Filters/CompanyUserFilter.php
@@ -44,7 +44,7 @@ class CompanyUserFilter extends SearchModelFilter
     public function q($value): CompanyUserFilter
     {
         return $this->whereHas('users',function ($q) use ($value) {
-            $q->where('name',$value);
+            $q->where('name', 'like', '%' . $value . '%');
             $q->orWhere('phone', 'like', '%' . $value . '%');
             $q->orWhere('email', 'like', '%' . $value . '%');
         });

--- a/modules/User/Presenters/UserPresenter.php
+++ b/modules/User/Presenters/UserPresenter.php
@@ -27,21 +27,30 @@ class UserPresenter extends AbstractPresenter
             'id' => $this->user->id,
             'name' => $this->user->name,
             'email' => $this->user->email,
-            'is_super_admin' => $this->user->hasRole("super-admin")||$this->user->is_owner?1:0,
+            'is_super_admin' => $this->user->hasRole("super-admin") || $this->user->is_owner ? 1 : 0,
             'phone' => $this->user->phone,
             'phone_code' => $this->user->phone_code,
-            "job_title_id"=>$this->user->userProfessionalData?->job_title_id,
-            'management_hierarchy_id' => $this->user->management_hierarchy_id ,
-            "branch_id"=>$this->user->managementHierarchy?->detail?->branch_id,
-            "roles"=>RoleSimplePresenter::collection($this->user->roles),
-            "branches"=>ManagementHierarchySimpleDataPresenter::collection($this->user->managementHierarchies(request()->role)->get()),
-            "status"=>$this->user->status,
+            "job_title_id" => $this->user->userProfessionalData?->job_title_id,
+            'management_hierarchy_id' => $this->user->management_hierarchy_id,
+            "branch_id" => $this->user->managementHierarchy?->detail?->branch_id,
+            "roles" => RoleSimplePresenter::collection($this->user->roles),
+            "branches" => ManagementHierarchySimpleDataPresenter::collection($this->user->managementHierarchies(request()->role)->get()),
+            "user_types" => $this->user->companyUserCompanies->map(function ($companyUserCompany) {
+                return [
+                    'id' => $companyUserCompany->id,
+                    'company_id' => $companyUserCompany->company_id,
+                    'global_company_user_id' => $companyUserCompany->global_company_user_id,
+                    'role' => $companyUserCompany->getRawOriginal('role'),
+                    'status' => $companyUserCompany->status,
+                ];
+            }),
+            "status" => $this->user->status,
 
 //            "permissions"=>PermissionPresenter::collection($this->user->getAllPermissions()),
-            "is_central_company"=>tenant("is_central_company"),
-            "residence"=>$this->user->companyUser?->residence,
-            "identity"=>$this->user->companyUser?->identity,
-            "country_id"=>$this->user->companyUser?->country_id,
+            "is_central_company" => tenant("is_central_company"),
+            "residence" => $this->user->companyUser?->residence,
+            "identity" => $this->user->companyUser?->identity,
+            "country_id" => $this->user->companyUser?->country_id,
         ];
     }
 }


### PR DESCRIPTION
## 🎯 Summary

- just add user types after authntication 
- i solve bugfix https://new-vision.atlassian.net/browse/CO-540 this only search like instead of exactly value 
## 🧾 Related Ticket

- no related jirra 
- [CO-540](https://new-vision.atlassian.net/browse/CO-540)

## 🔄 Type of Change

- [x] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Hotfix
- [ ] Chore / Maintenance

## 🧪 How to Test



## ✅ Checklist

- [x] Performed **self-review** of the code
- [ ] Updated **validations** if business logic changed
- [X] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [X] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [X] No database changes
- [ ] There is a new migration (describe below):


[CO-540]: https://new-vision.atlassian.net/browse/CO-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ