### PR TITLE
fix bugs legal-data error in FileObserver

### DIFF
--- a/modules/ArchiveLibrary/File/Observers/FileObserver.php
+++ b/modules/ArchiveLibrary/File/Observers/FileObserver.php
@@ -215,11 +215,21 @@ class FileObserver
         }
 
 
-        // Fallback to request for single file upload
+        // Fallback to request for single file upload or array of files named 'file'
         if (function_exists('request') && request()->hasFile('file')) {
-            $uploadedFile = request()->file('file');
-            if ($uploadedFile && $uploadedFile->isValid()) {
-                $sizeInBytes = $uploadedFile->getSize();
+            $uploadedData = request()->file('file');
+            if (is_array($uploadedData)) {
+                $totalSize = 0;
+                foreach ($uploadedData as $fileItem) {
+                    if ($fileItem && $fileItem->isValid()) {
+                        $totalSize += $fileItem->getSize();
+                    }
+                }
+                 if ($totalSize > 0) {
+                    return round($totalSize / (1024 * 1024), 2);
+                }
+            } elseif ($uploadedData && $uploadedData->isValid()) {
+                $sizeInBytes = $uploadedData->getSize();
                 return round($sizeInBytes / (1024 * 1024), 2);
             }
         }
@@ -250,11 +260,21 @@ class FileObserver
      */
     private function getNewFileSizeInMB(File $file)
     {
-        // Check for single file upload
+        // Check for single file upload or array of files named 'file'
         if (function_exists('request') && request()->hasFile('file')) {
-            $uploadedFile = request()->file('file');
-            if ($uploadedFile && $uploadedFile->isValid()) {
-                $sizeInBytes = $uploadedFile->getSize();
+            $uploadedData = request()->file('file');
+            if (is_array($uploadedData)) {
+                $totalSize = 0;
+                foreach ($uploadedData as $fileItem) {
+                    if ($fileItem && $fileItem->isValid()) {
+                        $totalSize += $fileItem->getSize();
+                    }
+                }
+                 if ($totalSize > 0) {
+                    return round($totalSize / (1024 * 1024), 2);
+                }
+            } elseif ($uploadedData && $uploadedData->isValid()) {
+                $sizeInBytes = $uploadedData->getSize();
                 return round($sizeInBytes / (1024 * 1024), 2);
             }
         }
@@ -285,10 +305,17 @@ class FileObserver
      */
     private function wasMediaChanged(File $file): bool
     {
-        // Check for single file upload
+        // Check for single file upload or array of files named 'file'
         if (function_exists('request') && request()->hasFile('file')) {
-            $uploadedFile = request()->file('file');
-            if ($uploadedFile && $uploadedFile->isValid()) {
+            $uploadedData = request()->file('file');
+
+            if (is_array($uploadedData)) {
+                foreach ($uploadedData as $fileItem) {
+                    if ($fileItem && $fileItem->isValid()) {
+                        return true;
+                    }
+                }
+            } elseif ($uploadedData && $uploadedData->isValid()) {
                 return true;
             }
         }


### PR DESCRIPTION
## 🎯 Summary
fix bugs legal-data error in FileObserver
-
## 🧾 Related Ticket

- Jira: [CO-604](https://new-vision.atlassian.net/browse/CO-604)

## 🔄 Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Hotfix
- [ ] Chore / Maintenance

## 🧪 How to Test

1. Call endpoint: `POSt /api/v1/companies/company-profile/legal-data/create-legal-data`
2. Use test data: `...`
<img width="368" height="140" alt="image" src="https://github.com/user-attachments/assets/c74f4eaf-9dc2-4fd9-b07b-dedcbd02a019" />

3. Expected result:
<img width="958" height="907" alt="image" src="https://github.com/user-attachments/assets/1258b7ba-e4e7-42cb-bf5a-8a405e2ea810" />

## ✅ Checklist

- [x] Performed **self-review** of the code
- [ ] Updated **validations** if business logic changed
- [ ] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [ ] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [x] No database changes
- [ ] There is a new migration (describe below):


[CO-604]: https://new-vision.atlassian.net/browse/CO-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ