### PR TITLE
fix count employess in branches

### DIFF
--- a/modules/Company/ManagementHierarchy/Models/ManagementHierarchy.php
+++ b/modules/Company/ManagementHierarchy/Models/ManagementHierarchy.php
@@ -17,6 +17,7 @@ use Modules\Attendance\Models\AttendanceConstraint;
 use Modules\User\Models\User;
 use Modules\Shared\JobType\Models\JobType;
 use Modules\JobTitle\Models\JobTitle;
+use Modules\UserInfo\UserProfessionalData\Models\UserProfessionalData;
 use Nevadskiy\Tree\AsTree;
 use Nevadskiy\Tree\Relations\HasManyDeep;
 use OwenIt\Auditing\Contracts\Auditable;
@@ -100,6 +101,15 @@ class ManagementHierarchy extends Model implements Auditable
     public function users()//get all users under hierarchy not in company
     {
         return HasManyDeep::between($this , User::class,"management_hierarchy_id","id");
+    }
+
+    /**
+     * Users professional data directly assigned to this branch (no recursion).
+     */
+    public function usersByBranch()
+    {
+        return $this->hasMany(UserProfessionalData::class, 'branch_id', 'id')
+            ->where('company_id', $this->company_id);
     }
 
     public function detail()

--- a/modules/Company/ManagementHierarchy/Presenters/ManagementHierarchyPresenter.php
+++ b/modules/Company/ManagementHierarchy/Presenters/ManagementHierarchyPresenter.php
@@ -19,8 +19,8 @@ class ManagementHierarchyPresenter extends AbstractPresenter
 
     protected function present(bool $isListing = false): array
     {
-        // Get users efficiently without n+1 query
-        $users = $this->managementHierarchy->users?->where("company_id", $this->managementHierarchy->company_id);
+        // Get users (including descendants) and filter by company to avoid cross-company leakage
+        $users = $this->managementHierarchy->usersByBranch?->where("company_id", $this->managementHierarchy->company_id);
 
         // Get cached hierarchy counts or calculate and cache them if not available
         $hierarchyCounts = $this->managementHierarchy->getCachedHierarchyCounts()


### PR DESCRIPTION
## 🎯 Summary

Fixed branch users relation to return direct user professional data per branch (usersByBranch), matching desired payload for /companies/company-profile/company-branches.
Updated presenter to use the direct branch users list (filtered by company) so users contains the expected entries (no recursion).
## 🧾 Related Ticket

- Jira: [CO-612](https://new-vision.atlassian.net/browse/CO-612)

## 🔄 Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Hotfix
- [ ] Chore / Maintenance

## 🧪 How to Test

1. Call endpoint: `GET /api/v1/companies/company-profile/company-branches`
2. Use test data: `...`
<img width="486" height="227" alt="image" src="https://github.com/user-attachments/assets/5ec674e6-7660-4c3c-a3d0-9e03789777ad" />

3. Expected result:
<img width="879" height="763" alt="image" src="https://github.com/user-attachments/assets/881eaf5b-a66b-4aee-9d69-48f3f6a53626" />

## ✅ Checklist

- [x] Performed **self-review** of the code
- [ ] Updated **validations** if business logic changed
- [ ] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [x] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [x] No database changes
- [ ] There is a new migration (describe below):


[CO-612]: https://new-vision.atlassian.net/browse/CO-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ