### PR TITLE
Fix job type seeder duplication and default company job types

### DIFF
--- a/modules/Company/ManagementHierarchy/Models/ManagementHierarchy.php
+++ b/modules/Company/ManagementHierarchy/Models/ManagementHierarchy.php
@@ -17,6 +17,7 @@ use Modules\Attendance\Models\AttendanceConstraint;
 use Modules\User\Models\User;
 use Modules\Shared\JobType\Models\JobType;
 use Modules\JobTitle\Models\JobTitle;
+use Modules\UserInfo\UserProfessionalData\Models\UserProfessionalData;
 use Nevadskiy\Tree\AsTree;
 use Nevadskiy\Tree\Relations\HasManyDeep;
 use OwenIt\Auditing\Contracts\Auditable;
@@ -100,6 +101,15 @@ class ManagementHierarchy extends Model implements Auditable
     public function users()//get all users under hierarchy not in company
     {
         return HasManyDeep::between($this , User::class,"management_hierarchy_id","id");
+    }
+
+    /**
+     * Users professional data directly assigned to this branch (no recursion).
+     */
+    public function usersByBranch()
+    {
+        return $this->hasMany(UserProfessionalData::class, 'branch_id', 'id')
+            ->where('company_id', $this->company_id);
     }
 
     public function detail()

--- a/modules/Company/ManagementHierarchy/Presenters/ManagementHierarchyPresenter.php
+++ b/modules/Company/ManagementHierarchy/Presenters/ManagementHierarchyPresenter.php
@@ -19,8 +19,8 @@ class ManagementHierarchyPresenter extends AbstractPresenter
 
     protected function present(bool $isListing = false): array
     {
-        // Get users efficiently without n+1 query
-        $users = $this->managementHierarchy->users?->where("company_id", $this->managementHierarchy->company_id);
+        // Get users (including descendants) and filter by company to avoid cross-company leakage
+        $users = $this->managementHierarchy->usersByBranch?->where("company_id", $this->managementHierarchy->company_id);
 
         // Get cached hierarchy counts or calculate and cache them if not available
         $hierarchyCounts = $this->managementHierarchy->getCachedHierarchyCounts()

--- a/modules/JobTitle/Database/Seeders/JobTitleModulesSeederTableSeeder.php
+++ b/modules/JobTitle/Database/Seeders/JobTitleModulesSeederTableSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Database\Eloquent\Model;
 use Modules\Company\CompanyCore\Models\Company;
 use Modules\JobTitle\Models\JobTitle;
+use Modules\Shared\JobType\Models\JobType;
 use Modules\Shared\JobType\DTO\CreateJobTypeWithCompanyDTO;
 use Modules\Shared\JobType\Services\JobTypeCRUDService;
 use Ranium\SeedOnce\Traits\SeedOnce;
@@ -25,6 +26,8 @@ class JobTitleModulesSeederTableSeeder extends Seeder
         $namespace = Uuid::NAMESPACE_DNS;
         $companyId = Uuid::uuid5($namespace, "new-vision")->toString();
 
+        $targetCompanyId = tenant("id") ?? $companyId;
+
         $data = [
 
             ['en' => 'General Manager', 'ar' => 'مدير عام','type'=>'general_manager']
@@ -32,22 +35,29 @@ class JobTitleModulesSeederTableSeeder extends Seeder
             //['en' => 'hr manager', 'ar' => 'مدير الموارد البشرية','type'=>'hr_manager'],
         ];
 
-        $createJobTypeWithCompanyDTO = new CreateJobTypeWithCompanyDTO(
-            name: 'مجلس ادارة',
-            companyId: Uuid::fromString(tenant("id") ?? $companyId),
-            status: 1
-        );
+        $jobType = JobType::where('company_id', $targetCompanyId)
+            ->whereHas('translations',function($q) use ($data){
+                $q->where('content','like','مجلس ادارة');
+            })
+            ->first();
 
-        $jobType = app(JobTypeCRUDService::class)->createWithCompany($createJobTypeWithCompanyDTO);
 
+        if (!$jobType) {
+            $createJobTypeWithCompanyDTO = new CreateJobTypeWithCompanyDTO(
+                name: 'مجلس ادارة',
+                companyId: Uuid::fromString($targetCompanyId),
+                status: 1
+            );
+            $jobType = app(JobTypeCRUDService::class)->createWithCompany($createJobTypeWithCompanyDTO);
+        }
 
         foreach ($data as $item) {
             JobTitle::firstOrCreate(
-                ['type' => $item['type'], "company_id" => tenant("id") ?? $companyId],
+                ['type' => $item['type'], "company_id" => $targetCompanyId],
                 [
                     'name' => ['en' => $item['en'], 'ar' => $item['ar']],
                     'type' => $item['type'],
-                    "company_id" => tenant("id") ?? $companyId,
+                    "company_id" => $targetCompanyId,
                     'description' => 'مدير عام',
                     'job_type_id' => $jobType->id,
                     'status' => 1


### PR DESCRIPTION
## 🎯 Summary

-Fix job type seeder duplication and default company job types
## 🧾 Related Ticket

- Jira: [CO-609](https://new-vision.atlassian.net/browse/CO-609)

## 🔄 Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Hotfix
- [ ] Chore / Maintenance
## 🧪 How to Test
1. Call endpoint: `GET /api/v1/job_types`
2. Use test data: `...`
<img width="486" height="89" alt="image" src="https://github.com/user-attachments/assets/536450ef-fb2f-40ad-991f-a63dfc1f6d91" />
3. Expected result:
<img width="865" height="938" alt="image" src="https://github.com/user-attachments/assets/327100cf-7c38-4237-966b-0bff8043f1e2" />

## ✅ Checklist

- [x] Performed **self-review** of the code
- [ ] Updated **validations** if business logic changed
- [ ] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [x] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [x] No database changes
- [ ] There is a new migration (describe below):


[CO-609]: https://new-vision.atlassian.net/browse/CO-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ