### PR TITLE
add permission/ecommerce in payment-method

### DIFF
--- a/lang/ar/names.php
+++ b/lang/ar/names.php
@@ -428,4 +428,9 @@ return [
     'ecommerce.page*page' => 'الصفحة',
     'page*page' => 'الصفحة',
 
+    // Payment Method
+    'payment-method' => 'طريقة الدفع',
+    'ecommerce.payment-method*payment-method' => 'طريقة الدفع',
+    'payment-method*payment-method' => 'طريقة الدفع',
+
 ];

--- a/lang/en/names.php
+++ b/lang/en/names.php
@@ -363,4 +363,9 @@ return [
     'page' => 'Page',
     'ecommerce.page*page' => 'Page',
     'page*page' => 'Page',
+
+    // Payment Method
+    'payment-method' => 'Payment Method',
+    'ecommerce.payment-method*payment-method' => 'Payment Method',
+    'payment-method*payment-method' => 'Payment Method',
 ];

--- a/modules/Ecommerce/Config/permissions.php
+++ b/modules/Ecommerce/Config/permissions.php
@@ -142,6 +142,15 @@ return [
         'ECOMMERCE_PAGE_UPDATE' => 'ecommerce.page*page.update',
         'ECOMMERCE_PAGE_DELETE' => 'ecommerce.page*page.delete',
         'ECOMMERCE_PAGE_EXPORT' => 'ecommerce.page*page.export',
+
+        // Payment Method Management
+        'ECOMMERCE_PAYMENT_METHOD_LIST' => 'ecommerce.payment-method*payment-method.list',
+        // 'ECOMMERCE_PAYMENT_METHOD_VIEW' => 'ecommerce.payment-method*payment-method.view',
+        // 'ECOMMERCE_PAYMENT_METHOD_CREATE' => 'ecommerce.payment-method*payment-method.create',
+        // 'ECOMMERCE_PAYMENT_METHOD_UPDATE' => 'ecommerce.payment-method*payment-method.update',
+        'ECOMMERCE_PAYMENT_METHOD_ACTIVATE' => 'ecommerce.payment-method*payment-method.activate',
+        // 'ECOMMERCE_PAYMENT_METHOD_DELETE' => 'ecommerce.payment-method*payment-method.delete',
+        // 'ECOMMERCE_PAYMENT_METHOD_EXPORT' => 'ecommerce.payment-method*payment-method.export',
     ]
 ];
 

--- a/modules/Ecommerce/PaymentMethod/Resources/routes/api.php
+++ b/modules/Ecommerce/PaymentMethod/Resources/routes/api.php
@@ -2,16 +2,17 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\Ecommerce\PaymentMethod\Controllers\PaymentMethodController;
+use Modules\RoleAndPermission\Enums\Permission;
 
 Route::group(['middleware' => ['auth:api']], function () {
-    Route::get('/', [PaymentMethodController::class, 'index']);
-    Route::post('/', [PaymentMethodController::class, 'store']);
-    Route::post('/export', [PaymentMethodController::class, 'export']);
+    Route::get('/', [PaymentMethodController::class, 'index'])->permission(Permission::ECOMMERCE_PAYMENT_METHOD_LIST());
+    // Route::post('/', [PaymentMethodController::class, 'store'])->permission(Permission::ECOMMERCE_PAYMENT_METHOD_CREATE());
+    // Route::post('/export', [PaymentMethodController::class, 'export'])->permission(Permission::ECOMMERCE_PAYMENT_METHOD_EXPORT());
 
-    Route::get('/{id}', [PaymentMethodController::class, 'show']);
-    Route::put('/{id}', [PaymentMethodController::class, 'update']);
-    Route::delete('/{id}', [PaymentMethodController::class, 'delete']);
+    // Route::get('/{id}', [PaymentMethodController::class, 'show'])->permission(Permission::ECOMMERCE_PAYMENT_METHOD_VIEW());
+    // Route::put('/{id}', [PaymentMethodController::class, 'update'])->permission(Permission::ECOMMERCE_PAYMENT_METHOD_UPDATE());
+    // Route::delete('/{id}', [PaymentMethodController::class, 'delete'])->permission(Permission::ECOMMERCE_PAYMENT_METHOD_DELETE());
     
     // Toggle status route
-    Route::patch('/{type}/toggle-status', [PaymentMethodController::class, 'toggleStatus']);
+    Route::patch('/{type}/toggle-status', [PaymentMethodController::class, 'toggleStatus'])->permission(Permission::ECOMMERCE_PAYMENT_METHOD_ACTIVATE());
 });


### PR DESCRIPTION
## 🎯 Summary

Add permission system for E-Commerce Payment Method module
Added ECOMMERCE_PAYMENT_METHOD_LIST and ECOMMERCE_PAYMENT_METHOD_ACTIVATE permissions
Updated Payment Method routes with permission middleware
Added English and Arabic translations for payment method permissions

## 🔄 Type of Change

- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Hotfix
- [ ] Chore / Maintenance

## 🧪 How to Test

1. Call endpoint: GET /api/v1/ecommerce/payment-methods
2. Use test data: User with/without ECOMMERCE_PAYMENT_METHOD_LIST permission
3. Expected result:
  User WITH permission: Returns list of payment methods (200 OK)
User WITHOUT permission: Returns 403 Forbidden


## ✅ Checklist

- [x] Performed **self-review** of the code
- [ ] Updated **validations** if business logic changed
- [ ] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [x] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [x] No database changes
- [ ] There is a new migration (describe below):
