### PR TITLE
Permission/ecommerce

### DIFF
--- a/modules/Attendance/Services/AttendanceConstraintService.php
+++ b/modules/Attendance/Services/AttendanceConstraintService.php
@@ -629,7 +629,7 @@ class AttendanceConstraintService
             'day_status' => 'Undefined',
             'reason' => 'No time schedule applied.',
             'periods' => [], // All active periods for today, including spillover
-            'is_holiday' => false,
+            'is_holiday' => true,
             'total_work_hours' => 0.0,
             'lateness_rules' => null,
             'early_clock_in_rules' => null,
@@ -676,7 +676,7 @@ class AttendanceConstraintService
              return array_merge($defaultResult, [
                 'day_status' => $workDayStatus,
                 'reason' => $workDayReason,
-                'is_holiday' => ($workDayStatus === 'holiday'),
+                'is_holiday' => true, // Always true when not a work day (holiday or weekend)
             ]);
         }
 

--- a/modules/Attendance/Services/UserAttendanceService.php
+++ b/modules/Attendance/Services/UserAttendanceService.php
@@ -269,10 +269,19 @@ class UserAttendanceService
             $totalHoursPresent += $att['total_hours_present'] ?? 0;
         }
         
+        // Determine if user can clock in
+        // Can clock in if period is active AND no active attendance exists
+        $hasActiveAttendance = collect($attendance)->contains(function ($att) {
+            return $att['status'] === 'active';
+        });
+        
+        $canClockIn = $isActive && !$hasActiveAttendance;
+        
         return array_merge($cleanedPeriod, [
             'total_work_hours' => $totalWorkHours,
             'is_active' => $isActive,
             'total_hours_present' => round($totalHoursPresent, 2),
+            'can_clock_in' => $canClockIn,
             'attendance' => $attendance,
         ]);
     }

--- a/modules/Attendance/Services/UserAttendanceService.php
+++ b/modules/Attendance/Services/UserAttendanceService.php
@@ -209,6 +209,8 @@ class UserAttendanceService
         // Get clock_in_time and clock_out_time
         $clockInTime = null;
         $clockOutTime = null;
+        $clockInCarbon = null;
+        $clockOutCarbon = null;
         
         if ($attendance->clock_in_time) {
             $clockInCarbon = $attendance->clock_in_time instanceof Carbon 
@@ -224,13 +226,26 @@ class UserAttendanceService
             $clockOutTime = $clockOutCarbon->format('H:i');
         }
 
+        // Calculate total hours present
+        $totalHoursPresent = 0;
+        if ($clockInCarbon) {
+            if ($clockOutCarbon) {
+                // If clocked out, calculate difference
+                $totalHoursPresent = round($clockInCarbon->diffInMinutes($clockOutCarbon) / 60, 2);
+            } else {
+                // If still active, calculate from clock_in to now
+                $totalHoursPresent = round($clockInCarbon->diffInMinutes(Carbon::now()) / 60, 2);
+            }
+        }
+
         return [
             'status' => $attendance->status ?? 'scheduled',
-            'date' => $startTime?->format('Y-m-d') ?? ($clockInTime ? Carbon::parse($attendance->clock_in_time)->format('Y-m-d') : null),
+            'date' => $startTime?->format('Y-m-d') ?? ($clockInTime ? $clockInCarbon->format('Y-m-d') : null),
             'start_time' => $startTime?->format('H:i'),
             'end_time' => $endTime?->format('H:i'),
             'clock_in_time' => $clockInTime,
             'clock_out_time' => $clockOutTime,
+            'total_hours_present' => $totalHoursPresent,
         ];
     }
 
@@ -247,10 +262,17 @@ class UserAttendanceService
     {
         $cleanedPeriod = $period;
         unset($cleanedPeriod['period_start_time_carbon'], $cleanedPeriod['period_end_time_carbon']);
-
+        
+        // Calculate total hours present from all attendance records in this period
+        $totalHoursPresent = 0;
+        foreach ($attendance as $att) {
+            $totalHoursPresent += $att['total_hours_present'] ?? 0;
+        }
+        
         return array_merge($cleanedPeriod, [
             'total_work_hours' => $totalWorkHours,
             'is_active' => $isActive,
+            'total_hours_present' => round($totalHoursPresent, 2),
             'attendance' => $attendance,
         ]);
     }


### PR DESCRIPTION
## 🎯 Summary

-add can_clock_in in attendance/user-constraint/today


## 🔄 Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Hotfix
- [ ] Chore / Maintenance

## 🧪 How to Test

1. Call endpoint: `GET /api/v1/attendance/user-constraint/today`
2. Use test data: `...`
<img width="492" height="149" alt="image" src="https://github.com/user-attachments/assets/57eac235-b104-4bd8-9a96-80e18229f81e" />


3. Expected result:
 <img width="702" height="737" alt="image" src="https://github.com/user-attachments/assets/3a7d82ea-8035-468e-912b-91dab9c4a57b" />

## ✅ Checklist

- [x] Performed **self-review** of the code
- [ ] Updated **validations** if business logic changed
- [x] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [x] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [x] No database changes
- [ ] There is a new migration (describe below):
