### PR TITLE
make naming of category unique

### DIFF
--- a/modules/WebsiteCMS/CategoryWebsiteCMS/Requests/CreateCategoryWebsiteCMSRequest.php
+++ b/modules/WebsiteCMS/CategoryWebsiteCMS/Requests/CreateCategoryWebsiteCMSRequest.php
@@ -6,16 +6,28 @@ namespace Modules\WebsiteCMS\CategoryWebsiteCMS\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Modules\WebsiteCMS\CategoryWebsiteCMS\Enum\CategoryWebsiteCMSType;
+use Modules\WebsiteCMS\CategoryWebsiteCMS\Models\CategoryWebsiteCMS;
 use Ramsey\Uuid\Uuid;
 use Modules\WebsiteCMS\CategoryWebsiteCMS\DTO\CreateCategoryWebsiteCMSDTO;
+use Modules\WebsiteCMS\CategoryWebsiteCMS\Rules\UniqueTranslationRule;
 
 class CreateCategoryWebsiteCMSRequest extends FormRequest
 {
     public function rules(): array
     {
         return [
-            'name_ar' => 'required|string|max:255',
-            'name_en' => 'required|string|max:255',
+            'name_ar' => [
+                'required',
+                'string',
+                'max:255',
+                new UniqueTranslationRule(new CategoryWebsiteCMS, 'name', 'ar')
+            ],
+            'name_en' => [
+                'required',
+                'string',
+                'max:255',
+                new UniqueTranslationRule(new CategoryWebsiteCMS, 'name', 'en')
+            ],
             'category_type' => 'required|in:'.implode(',', CategoryWebsiteCMSType::values()),
         ];
     }

--- a/modules/WebsiteCMS/CategoryWebsiteCMS/Requests/UpdateCategoryWebsiteCMSRequest.php
+++ b/modules/WebsiteCMS/CategoryWebsiteCMS/Requests/UpdateCategoryWebsiteCMSRequest.php
@@ -6,17 +6,31 @@ namespace Modules\WebsiteCMS\CategoryWebsiteCMS\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Modules\WebsiteCMS\CategoryWebsiteCMS\Enum\CategoryWebsiteCMSType;
+use Modules\WebsiteCMS\CategoryWebsiteCMS\Models\CategoryWebsiteCMS;
 use Ramsey\Uuid\Uuid;
 use Modules\WebsiteCMS\CategoryWebsiteCMS\Commands\UpdateCategoryWebsiteCMSCommand;
 use Modules\WebsiteCMS\CategoryWebsiteCMS\Handlers\UpdateCategoryWebsiteCMSHandler;
+use Modules\WebsiteCMS\CategoryWebsiteCMS\Rules\UniqueTranslationRule;
 
 class UpdateCategoryWebsiteCMSRequest extends FormRequest
 {
     public function rules(): array
     {
+        $categoryId = $this->route('id');
+
         return [
-            'name_ar' => 'required|string|max:255',
-            'name_en' => 'required|string|max:255',
+            'name_ar' => [
+                'required',
+                'string',
+                'max:255',
+                new UniqueTranslationRule(new CategoryWebsiteCMS, 'name', 'ar', $categoryId)
+            ],
+            'name_en' => [
+                'required',
+                'string',
+                'max:255',
+                new UniqueTranslationRule(new CategoryWebsiteCMS, 'name', 'en', $categoryId)
+            ],
             'category_type' => 'required|in:'.implode(",",CategoryWebsiteCMSType::values()),
         ];
     }

--- a/modules/WebsiteCMS/CategoryWebsiteCMS/Rules/UniqueTranslationRule.php
+++ b/modules/WebsiteCMS/CategoryWebsiteCMS/Rules/UniqueTranslationRule.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\WebsiteCMS\CategoryWebsiteCMS\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+
+class UniqueTranslationRule implements Rule
+{
+    protected Model $model;
+    protected string $column;
+    protected string $locale;
+    protected ?string $ignoreId;
+    protected ?string $tenantColumn;
+
+
+    public function __construct(
+        Model $model,
+        string $column,
+        string $locale,
+        ?string $ignoreId = null,
+        ?string $tenantColumn = 'company_id'
+    ) {
+        $this->model = $model;
+        $this->column = $column;
+        $this->locale = $locale;
+        $this->ignoreId = $ignoreId;
+        $this->tenantColumn = $tenantColumn;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        $query = $this->model::query()
+            ->whereHas("translations",function ($q)use ($value){
+                $q->where("locale", $this->locale)->where("content", $value)->where("field", $this->column);
+
+            });
+
+        // Add tenant scope if tenant column is specified
+        if ($this->tenantColumn && function_exists('tenant')) {
+            $query->where($this->tenantColumn, tenant('id'));
+        }
+
+        // Ignore specific ID for update operations
+        if ($this->ignoreId) {
+            $query->where('id', '!=', $this->ignoreId);
+        }
+
+        return !$query->exists();
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message(): string
+    {
+        $localeLabel = $this->locale === 'ar' ? 'Arabic' : 'English';
+        return "The {$localeLabel} {$this->column} has already been taken.";
+    }
+}


### PR DESCRIPTION
## 🎯 Summary

- make name in category cms unique in create , update API
## 🧾 Related Ticket

- Jira: [CO-647](https://new-vision.atlassian.net/browse/CO-647)

## 🔄 Type of Change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Hotfix
- [x] Chore / Maintenance

## 🧪 How to Test

<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/be0af37d-2fb0-4e9b-8fb0-1d440072fc68" />

<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/9c8a3ffd-a879-487b-a6c4-77ed6bca95aa" />

## ✅ Checklist

- [x] Performed **self-review** of the code
- [x] Updated **validations** if business logic changed
- [x] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [X] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [x] No database changes
- [ ] There is a new migration (describe below):


[CO-647]: https://new-vision.atlassian.net/browse/CO-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ