### PR TITLE
fix delete this after change bussnies logic

### DIFF
--- a/modules/WebsiteCMS/CategoryWebsiteCMS/Filters/CategoryWebsiteCMSFilter.php
+++ b/modules/WebsiteCMS/CategoryWebsiteCMS/Filters/CategoryWebsiteCMSFilter.php
@@ -17,6 +17,14 @@ class CategoryWebsiteCMSFilter extends SearchModelFilter
         });
     }
 
+
+    public function search($name)
+    {
+        return $this->whereHas("translations",function ($query) use ($name) {
+            $query->where('content', 'like', '%' . $name . '%');
+        });
+    }
+
     public function CategoryType($type)
     {
         return $this->where('category_type', $type);

--- a/modules/WebsiteCMS/CategoryWebsiteCMS/Models/CategoryWebsiteCMS.php
+++ b/modules/WebsiteCMS/CategoryWebsiteCMS/Models/CategoryWebsiteCMS.php
@@ -12,6 +12,7 @@ use BasePackage\Shared\Traits\BaseFilterable;
 use BasePackage\Shared\Traits\HasTranslations;
 use Modules\Company\CompanyCore\Models\Company;
 use Modules\WebsiteCMS\WebsiteIcon\Models\WebsiteIcon;
+use Modules\WebsiteCMS\WebsiteNews\Models\WebsiteNews;
 use Modules\WebsiteCMS\WebsiteService\Models\WebsiteService;
 use Stancl\Tenancy\Database\Concerns\BelongsToTenant;
 
@@ -54,9 +55,9 @@ class CategoryWebsiteCMS extends Model
 
     }
 
-    public function websiteIcons()
+    public function websiteNews()
     {
-        return $this->hasMany(WebsiteIcon::class, "category_website_cms_id", "id");
+        return $this->hasMany(WebsiteNews::class, "category_website_cms_id", "id");
     }
 
     protected static function newFactory(): CategoryWebsiteCMSFactory

--- a/modules/WebsiteCMS/CategoryWebsiteCMS/Repositories/CategoryWebsiteCMSRepository.php
+++ b/modules/WebsiteCMS/CategoryWebsiteCMS/Repositories/CategoryWebsiteCMSRepository.php
@@ -59,7 +59,7 @@ class CategoryWebsiteCMSRepository extends BaseRepository
     {
         $category = $this->find($id);
 
-        if ($category->websiteServices()->count() > 0||$category->websiteIcons()->count() > 0)
+        if ($category->websiteServices()->count() > 0||$category->websiteNews()->count() > 0)
         {
             throw new CustomException(__("validation.can-not-delete-has-children"));
         }


### PR DESCRIPTION
## 🎯 Summary

- fix delete category after change childrens from iconsto news as businesses logic 
- fix search frontend send param name search not name 
- 
## 🧾 Related Ticket

- Jira: [CO-649](https://new-vision.atlassian.net/browse/CO-649)
- Jira:[CO-642](https://new-vision.atlassian.net/browse/CO-642)

## 🔄 Type of Change

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [x] Hotfix
- [x] Chore / Maintenance

## 🧪 How to Test
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/55b6858d-3466-4775-9094-86f8fc6b1b22" />


<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/c8f79d79-3459-4929-9a06-1eaa6e8a0797" />


## ✅ Checklist

- [x] Performed **self-review** of the code
- [ ] Updated **validations** if business logic changed
- [x] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [x] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [x] No database changes
- [ ] There is a new migration (describe below):


[CO-649]: https://new-vision.atlassian.net/browse/CO-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CO-642]: https://new-vision.atlassian.net/browse/CO-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ