### PR TITLE
Attendance

### DIFF
--- a/modules/Attendance/Controllers/LocationTrackingController.php
+++ b/modules/Attendance/Controllers/LocationTrackingController.php
@@ -70,13 +70,26 @@ class LocationTrackingController
             $enhancedTrackingPoint = $trackingPoint->toArray();
             $enhancedTrackingPoint['type'] = $type;
             $enhancedTrackingPoint['is_mock'] = $isMock;
+            // Map device uuid & accuracy if provided by client
+            if (!empty($trackingData['uuid'])) {
+                $enhancedTrackingPoint['uuid'] = $trackingData['uuid'];
+                // keep device_id in sync for backward compatibility
+                $enhancedTrackingPoint['device_id'] = $trackingData['uuid'];
+            }
+            if (isset($trackingData['accuracy'])) {
+                $enhancedTrackingPoint['accuracy'] = (float) $trackingData['accuracy'];
+            }
             
             // Add type-specific data
             if ($type === 'track') {
                 $enhancedTrackingPoint['gps_status'] = $trackingData['gps_status'];
+                $enhancedTrackingPoint['event'] = 'location';
             } elseif ($type === 'geofence') {
                 $enhancedTrackingPoint['action'] = $trackingData['action'];
                 $enhancedTrackingPoint['geofence_id'] = $trackingData['geofence_id'];
+                // New naming as requested by mobile payload
+                $enhancedTrackingPoint['geofence_action'] = $trackingData['action'];
+                $enhancedTrackingPoint['event'] = 'geofence';
             }
             
             $enhancedTrackingPoint['processed_at'] = now()->toISOString();

--- a/modules/Attendance/Models/Attendance.php
+++ b/modules/Attendance/Models/Attendance.php
@@ -700,19 +700,32 @@ class Attendance extends Model implements Auditable
 
         // 7. Calculate Late and Early Departure
         // *** IMPROVED: Get scheduled start and end times from user/company settings ***
-        $scheduledStartTimeString = $this->start_time ?? $this->user->start_time ?? '09:00';
-        $scheduledEndTimeString = $this->end_time ?? $this->user->end_time ?? '17:00';
+        $scheduledStartCandidate = $this->start_time ?? $this->user->start_time ?? '09:00';
+        $scheduledEndCandidate = $this->end_time ?? $this->user->end_time ?? '17:00';
+
+        // Normalize possible Carbon or datetime strings to plain time strings (H:i:s)
+        if ($scheduledStartCandidate instanceof \Carbon\Carbon) {
+            $scheduledStartTimeString = $scheduledStartCandidate->format('H:i:s');
+        } else {
+            $scheduledStartTimeString = (string) $scheduledStartCandidate;
+            if (is_string($scheduledStartCandidate) && (str_contains($scheduledStartCandidate, 'T') || str_contains($scheduledStartCandidate, ' '))) {
+                $scheduledStartTimeString = \Carbon\Carbon::parse($scheduledStartCandidate)->format('H:i:s');
+            }
+        }
+
+        if ($scheduledEndCandidate instanceof \Carbon\Carbon) {
+            $scheduledEndTimeString = $scheduledEndCandidate->format('H:i:s');
+        } else {
+            $scheduledEndTimeString = (string) $scheduledEndCandidate;
+            if (is_string($scheduledEndCandidate) && (str_contains($scheduledEndCandidate, 'T') || str_contains($scheduledEndCandidate, ' '))) {
+                $scheduledEndTimeString = \Carbon\Carbon::parse($scheduledEndCandidate)->format('H:i:s');
+            }
+        }
+
         try {
             $scheduledStartTime = $clockIn->copy()->setTimeFromTimeString($scheduledStartTimeString);
             $scheduledEndTime = $clockIn->copy()->setTimeFromTimeString($scheduledEndTimeString);
         } catch (\Exception $e) {
-            Log::warning('Invalid scheduled start or end time format.  Using defaults.', [
-                'user_id' => $this->user_id,
-                'company_id' => $this->company_id,
-                'scheduled_start_time' => $scheduledStartTimeString,
-                'scheduled_end_time' => $scheduledEndTimeString,
-                'error' => $e->getMessage(),
-            ]);
             // Fallback to default values if parsing fails
             $scheduledStartTime = $clockIn->copy()->setHour(9)->setMinute(0)->setSecond(0);
             $scheduledEndTime = $clockIn->copy()->setHour(17)->setMinute(0)->setSecond(0);

--- a/modules/Attendance/Presenters/LiveTrackingPresenter.php
+++ b/modules/Attendance/Presenters/LiveTrackingPresenter.php
@@ -15,13 +15,10 @@ class LiveTrackingPresenter extends AbstractPresenter
 
     public function present(bool $isListing = false): array
     {
-        // Get all tracking points, or an empty array if none.
         $allTrackingPoints = $this->attendance->location_tracking ?? [];
 
-        // Get last 4 tracking points in descending order
         $trackingPoints = array_slice(array_reverse($allTrackingPoints), 0, 4);
 
-        // Find the most recent tracking point (first in reversed array)
         $latestPoint = !empty($trackingPoints) ? $trackingPoints[0] : null;
 
         return [
@@ -48,7 +45,6 @@ class LiveTrackingPresenter extends AbstractPresenter
             'is_absent' => (int) $this->attendance->is_absent,
             'is_holiday' => (int) $this->attendance->is_holiday,
 
-            // --- Latest Location Info (for the marker) ---
             'latest_location' => $latestPoint ? [
                 'latitude'  => (float) $latestPoint['latitude'],
                 'longitude' => (float) $latestPoint['longitude'],
@@ -57,6 +53,9 @@ class LiveTrackingPresenter extends AbstractPresenter
                 'type' => $latestPoint['type'] ?? 'track',
                 'is_mock' => $latestPoint['is_mock'] ?? false,
                 'device_id' => $latestPoint['device_id'] ?? 'unknown',
+                'uuid' => $latestPoint['uuid'] ?? ($latestPoint['device_id'] ?? 'unknown'),
+                'geofence_action' => $latestPoint['geofence_action'] ?? null,
+                'event' => $latestPoint['event'] ?? 'location',
                 'location_source' => $latestPoint['location_source'] ?? 'GPS',
             ] : [
                 'latitude'  => $this->attendance->clock_in_location['latitude'] ?? 0,
@@ -66,10 +65,12 @@ class LiveTrackingPresenter extends AbstractPresenter
                 'type' => 'clock_in',
                 'is_mock' => false,
                 'device_id' => 'unknown',
+                'uuid' => 'unknown',
+                'geofence_action' => null,
+                'event' => 'location',
                 'location_source' => 'GPS',
             ],
 
-            // --- All tracking points with enhanced data ---
             'tracking_points' => array_map(function ($point) {
                 return [
                     'latitude' => (float) $point['latitude'],
@@ -79,6 +80,9 @@ class LiveTrackingPresenter extends AbstractPresenter
                     'type' => $point['type'] ?? 'track',
                     'is_mock' => $point['is_mock'] ?? false,
                     'device_id' => $point['device_id'] ?? 'unknown',
+                    'uuid' => $point['uuid'] ?? ($point['device_id'] ?? 'unknown'),
+                    'geofence_action' => $point['geofence_action'] ?? null,
+                    'event' => $point['event'] ?? 'location',
                     'location_source' => $point['location_source'] ?? 'GPS',
                     'gps_status' => $point['gps_status'] ?? null,
                     'action' => $point['action'] ?? null,
@@ -87,7 +91,6 @@ class LiveTrackingPresenter extends AbstractPresenter
                 ];
             }, $trackingPoints),
 
-            // --- Simple tracking path for map display ---
             'tracking_path' => array_map(function ($point) {
                 return [
                     'lat' => (float) $point['latitude'],
@@ -97,7 +100,6 @@ class LiveTrackingPresenter extends AbstractPresenter
                 ];
             }, $trackingPoints),
 
-            // --- Statistics ---
             'tracking_stats' => [
                 'total_points' => count($trackingPoints),
                 'track_points' => count(array_filter($trackingPoints, fn($p) => ($p['type'] ?? 'track') === 'track')),

--- a/modules/Attendance/Requests/TrackLocationRequest.php
+++ b/modules/Attendance/Requests/TrackLocationRequest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Modules\Attendance\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Modules\Attendance\DataClasses\LocationTrackingPoint;
 
 class TrackLocationRequest extends FormRequest
@@ -22,12 +24,60 @@ class TrackLocationRequest extends FormRequest
             '*.lng' => ['required', 'numeric', 'between:-180,180'],
             '*.timestamp' => ['required', 'string'],
             '*.is_mock' => ['required', 'boolean'],
+            '*.uuid' => ['sometimes', 'string', 'max:255'],
+            '*.accuracy' => ['sometimes', 'numeric', 'min:0'],
             
             '*.gps_status' => ['required_if:*.type,track', 'string'],
             
             '*.action' => ['required_if:*.type,geofence', 'string'],
             '*.id' => ['required_if:*.type,geofence', 'string'],
         ];
+    }
+
+    /**
+     * Customize validation failure response to include expected payload shape and examples.
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        $expectedFormat = [[
+            'type' => 'track|geofence',
+            'lat' => 0.0,
+            'lng' => 0.0,
+            'is_mock' => false,
+            'timestamp' => '2025-12-23T19:08:00Z',
+            'gps_status' => 'required when type=track',
+            'action' => 'enter|exit (required when type=geofence)',
+            'id' => 'geofence_identifier (required when type=geofence)',
+        ]];
+
+        $example = [
+            [
+                'type' => 'track',
+                'lat' => 29.996442,
+                'lng' => 30.9024529,
+                'is_mock' => false,
+                'gps_status' => 'enabled',
+                'timestamp' => '2025-12-23T19:08:00Z',
+            ],
+            [
+                'type' => 'geofence',
+                'lat' => 29.996442,
+                'lng' => 30.9024529,
+                'action' => 'enter',
+                'id' => 'office_main_branch',
+                'is_mock' => false,
+                'timestamp' => '2025-12-23T19:08:00Z',
+            ],
+        ];
+
+        throw new HttpResponseException(response()->json([
+            'success' => false,
+            'message' => 'فشل التحقق من الصحة',
+            'errors' => $validator->errors(),
+            'expected_format' => $expectedFormat,
+            'example' => $example,
+            'received' => $this->all(),
+        ], 422));
     }
 
     /**
@@ -55,8 +105,8 @@ class TrackLocationRequest extends FormRequest
                 'latitude' => $data['lat'],
                 'longitude' => $data['lng'],
                 'timestamp' => $data['timestamp'],
-                'accuracy' => 5.0,
-                'device_id' => 'mobile-app',
+                'accuracy' => $data['accuracy'] ?? 5.0,
+                'device_id' => $data['uuid'] ?? 'mobile-app',
                 'app_version' => '1.0.0',
                 'battery_level' => 100,
                 'network_type' => '4G',
@@ -70,6 +120,8 @@ class TrackLocationRequest extends FormRequest
                 'gps_status' => $data['gps_status'] ?? null,
                 'action' => $data['action'] ?? null,
                 'geofence_id' => $data['id'] ?? null,
+                'uuid' => $data['uuid'] ?? null,
+                'accuracy' => $data['accuracy'] ?? 5.0,
             ];
         }
         


### PR DESCRIPTION
## 🎯 Summary

- Add array-based payload for `POST {{baseUrl}}/attendance/track-location` supporting `track` and `geofence`.
- Map new fields and unify naming:
  - `uuid` → saved as both `uuid` and `device_id`.
  - `accuracy` (float).
  - `event` auto-derived (`location` for `track`, `geofence` for `geofence`).
  - `geofence_action` derived from `action` for `geofence`.
- Persist all items into `attendance.location_tracking` with enriched metadata.
- Improve `GET {{baseUrl}}/attendance/live-tracking`:
  - Return `latest_location`.
  - Return `tracking_points` limited to last 4 points in descending order.
  - Include `tracking_path` and summaries.
- Custom 422 validation response on `track-location`:
  - Includes `errors`, `expected_format`, `example`, and `received` payload for easier debugging.
- Fix clock-out error by normalizing scheduled start/end to `H:i:s` strings.

## 🔄 Type of Change

- [x] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Hotfix
- [ ] Chore / Maintenance

## 🧪 How to Test

1. Call endpoint: `POST {{baseUrl}}/attendance/track-location`
   - Body (array):
     ```json
     [
       {
         "type": "track",
         "lat": 29.996442,
         "lng": 30.9024529,
         "is_mock": false,
         "gps_status": "enabled",
         "timestamp": "2025-12-23T19:08:00Z",
         "uuid": "iPhone-14-Pro",
         "accuracy": 7.5
       },
       {
         "type": "geofence",
         "lat": 29.996442,
         "lng": 30.9024529,
         "action": "ENTER",
         "id": "office_main_branch",
         "is_mock": false,
         "timestamp": "2025-12-23T19:09:00Z",
         "uuid": "iPhone-14-Pro",
         "accuracy": 6.2
       }
     ]
     ```
   - Expected:
     - 200 SUCCESS with `processed_count` and `processed_data`.
     - Items appended to `attendance.location_tracking` with `uuid`, `device_id`, `event`, `geofence_action`, `accuracy`, etc.
     - If any item has `is_mock = true`, returns 422 with a clear message.

2. Call endpoint: `GET {{baseUrl}}/attendance/live-tracking`
   - Expected:
     - Each active attendance includes:
       - `latest_location` with `latitude`, `longitude`, `timestamp`, `accuracy`, `type`, `is_mock`, `device_id`, `uuid`, `geofence_action`, `event`.
       - `tracking_points`: last 4 points only, in descending order by time, same metadata.
       - `tracking_path` (simple lat/lng path).
       - Stats summary.

3. Validation error example (422) on `track-location`
   - Send invalid data (e.g., `type: "invalid"`).
   - Expected:
     - Response contains `errors`, `expected_format`, `example`, and `received` for debugging.

## ✅ Checklist

- [x] Performed **self-review** of the code
- [x] Updated **validations** if business logic changed
- [x] Updated **API docs / Postman collection** if the endpoint changed
- [ ] All **tests are passing** (if applicable)
- [ ] No **breaking changes** for existing clients

## 🧱 Migration / Database Changes

- [x] No database changes
- [ ] There is a new migration (describe below):